### PR TITLE
Create Post List and Post Item

### DIFF
--- a/src/components/Main/PostItem.tsx
+++ b/src/components/Main/PostItem.tsx
@@ -1,0 +1,120 @@
+import React, {FunctionComponent} from 'react';
+import styled from '@emotion/styled';
+import {Link} from 'gatsby';
+
+//PostItem이 받아오는 props: 제목, 날짜, 카테고리, 요약, 썸네일, 링크
+type PostItemProps = {
+    title: string
+    date: string
+    categories: string[]
+    summary: string
+    thumbnail: string
+    link: string
+}
+
+const PostItemWrapper = styled(Link)`
+display: flex;
+flex-direction: column;
+border-radius: 10px;
+box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
+transition: 0.3s box-shadow;
+cursor: pointer;
+background-color: #ffffff;
+
+&:hover {
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+`
+
+//추가 학습이 필요한 CSS 속성 또는 속성값: object-fit
+const ThumbnailImage = styled.img`
+  width: 100%;
+  height: 200px;
+  border-radius: 10px 10px 0 0;
+  object-fit: cover;
+`
+
+const PostItemContent = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 15px;
+`
+
+//추가 학습이 필요한 CSS 속성 또는 속성값: -webkit-box, text-overflow,
+//white-space, overflow-wrap, -webkit-line-clamp,
+//-webkit-box-orient
+const Title = styled.div`
+  display: -webkit-box;
+  overflow: hidden;
+  margin-bottom: 3px;
+  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 20px;
+  font-weight: 700;
+`
+
+const Date = styled.div`
+  font-size: 14px;
+  font-weight: 400;
+  opacity: 0.7;
+`
+
+const Category = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  margin: 10px -5px;
+`
+
+const CategoryItem = styled.div`
+  margin: 2.5px 5px;
+  padding: 3px 5px;
+  border-radius: 3px;
+  background: black;
+  font-size: 14px;
+  font-weight: 700;
+  color: white;
+`
+
+//추가 학습이 필요한 CSS 속성 또는 속성값: Title 컴포넌트와 동일
+const Summary = styled.div`
+  display: -webkit-box;
+  overflow: hidden;
+  margin-top: auto;
+  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 16px;
+  opacity: 0.8;
+`
+
+const PostItem:FunctionComponent<PostItemProps> = function({
+    title,
+    date,
+    categories,
+    summary,
+    thumbnail,
+    link
+}){
+    return(
+    <PostItemWrapper to={link}>
+        <ThumbnailImage src={thumbnail} alt="Post Item Image"/>
+        <PostItemContent>
+            <Title>{title}</Title>
+            <Date>{date}</Date>
+            <Category>{categories.map((category)=>(
+                <CategoryItem key={category}>{category}</CategoryItem>
+            ))}</Category>
+            <Summary>{summary}</Summary>
+        </PostItemContent>
+    </PostItemWrapper>
+    )
+}
+
+export default PostItem;

--- a/src/components/Main/PostList.tsx
+++ b/src/components/Main/PostList.tsx
@@ -1,0 +1,40 @@
+import React, { FunctionComponent } from 'react'
+import styled from '@emotion/styled'
+import PostItem from './PostItem'
+
+
+//개별 PostItem 컴포넌트에 전달되는 props 더미 데이터
+const POST_ITEM_DATA = {
+  title: 'Post Item Title',
+  date: '2020.01.29.',
+  categories: ['Web', 'Frontend', 'Testing'],
+  summary:
+    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Provident repellat doloremque fugit quis rem temporibus! Maxime molestias, suntrem debitis odit harum impedit. Modi cupiditate harum dignissimos eos in corrupti!',
+  thumbnail:
+    'https://images.unsplash.com/photo-1629757509637-7c99379d6d26?crop=entropy&cs=tinysrgb&fm=jpg&ixlib=rb-1.2.1&q=80&raw_url=true&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770',
+  link: 'https://www.google.co.kr/',
+}
+
+const PostListWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 20px;
+  width: 768px;
+  margin: 0 auto;
+  padding: 50px 0;
+  background-color: tomato;
+`
+
+const PostList: FunctionComponent = function () {
+  return (
+  <PostListWrapper>
+    <PostItem {...POST_ITEM_DATA}/>
+    <PostItem {...POST_ITEM_DATA}/>
+    <PostItem {...POST_ITEM_DATA}/>
+    <PostItem {...POST_ITEM_DATA}/>
+  </PostListWrapper>
+  )
+
+}
+
+export default PostList

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,8 @@ import GlobalStyle from 'components/Common/GlobalStyle';
 import Introduction from 'components/Main/Introduction';
 import Footer from 'components/Common/Footer';
 import CategoryList from 'components/Main/CategoryList';
+import PostList from 'components/Main/PostList';
+
 
 //categoryList props에 전달할 더미 데이터 생성
 const CATEGORY_LIST = {
@@ -25,6 +27,7 @@ const IndexPage: FunctionComponent = function(){
             <GlobalStyle />
             <Introduction />
             <CategoryList selectedCategory='Web' categoryList={CATEGORY_LIST}/>
+            <PostList />
             <Footer />
         </Container>
     )


### PR DESCRIPTION
### Post List 구현

- 블로그의 개별 Post Item들을 나열할 Post List 컴포넌트를 생성했습니다.
- Post Item들을 정렬하기 위해 grid로 스타일링했습니다.
- 영역을 식별하기 위해 임시로 backgroun-color 속성을 지정해주었습니다.

### Post Item 구현

- 개별 Post Item 컴포넌트를 생성했습니다.
- 제목, 날짜, 카테고리, 요약, 썸네일, url을 props로 받습니다.
- PostList.tsx에 POST_ITEM_DATA라는 더미 데이터를 생성해 props를 전달했습니다.
- PostItem.tsx에서 각각의 props를 사용하는 styled-components를 생성했습니다.

### 주석 추가

- 추가 학습이 필요한 CSS 속성 및 속성값을 주석으로 메모해두었습니다.
- 이후 학습이 완료되면 삭제할 예정입니다.