### PR TITLE
Passing Query Data as props

### DIFF
--- a/src/components/Main/PostList.tsx
+++ b/src/components/Main/PostList.tsx
@@ -15,6 +15,27 @@ const POST_ITEM_DATA = {
   link: 'https://www.google.co.kr/',
 }
 
+//index.tsx에서 받아온 데이터 중에서 PostList에서 사용되는 데이터를 옮겼습니다.
+export type PostType = {
+  node: {
+    id: string
+    frontmatter: {
+      title: string
+      summary: string
+      date: string
+      categories: string[]
+      thumbnail: {
+        publicURL: string
+      }
+    }
+  }
+}
+
+//props의 타입 지정
+type PostListProps = {
+  posts: PostType[]
+}
+
 const PostListWrapper = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -31,7 +52,7 @@ const PostListWrapper = styled.div`
   }
 `
 
-const PostList: FunctionComponent = function () {
+const PostList: FunctionComponent<PostListProps> = function () {
   return (
   <PostListWrapper>
     <PostItem {...POST_ITEM_DATA}/>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,8 +6,9 @@ import GlobalStyle from 'components/Common/GlobalStyle';
 import Introduction from 'components/Main/Introduction';
 import Footer from 'components/Common/Footer';
 import CategoryList from 'components/Main/CategoryList';
-import PostList from 'components/Main/PostList';
-
+//PostList 컴포넌트로 옮긴 데이터를 불러옵니다.
+import PostList, {PostType} from 'components/Main/PostList';
+import { graphql } from 'gatsby';
 
 //categoryList props에 전달할 더미 데이터 생성
 const CATEGORY_LIST = {
@@ -21,16 +22,53 @@ const Container = styled.div`
     flex-direction: column;
     height: 100vh;
 `
-const IndexPage: FunctionComponent = function(){
+
+//쿼리로 받아온 데이터 타입을 지정합니다.
+type IndexPageProps = {
+    data: {
+      allMarkdownRemark: {
+        edges: PostType[]
+      }
+    }
+  }
+
+const IndexPage: FunctionComponent<IndexPageProps> = function({
+    data: {
+        allMarkdownRemark: { edges },
+    },
+}){
     return (
         <Container>
             <GlobalStyle />
             <Introduction />
             <CategoryList selectedCategory='Web' categoryList={CATEGORY_LIST}/>
-            <PostList />
+            <PostList posts={edges}/>
             <Footer />
         </Container>
     )
 }
 
 export default IndexPage;
+
+export const getPostList = graphql`
+  query getPostList {
+    allMarkdownRemark(
+      sort: { order: DESC, fields: [frontmatter___date, frontmatter___title] }
+    ) {
+      edges {
+        node {
+          id
+          frontmatter {
+            title
+            summary
+            date(formatString: "YYYY.MM.DD.")
+            categories
+            thumbnail {
+              publicURL
+            }
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
### 쿼리 데이터 pops로 전달

- GraphQL 쿼리문으로 받아온 데이터를 props로 받아옵니다.
- index.tsx에서 PostList 컴포넌트로 props로 전달합니다.
- TypeScript로 각각의 데이터와 props의 타입을 지정했습니다.