### PR TITLE
Feature: URL 카테고리 파싱

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-transformer-sharp": "^4.15.0",
     "prismjs": "^1.28.0",
     "prop-types": "^15.8.1",
+    "query-string": "^7.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import PostList from 'components/Main/PostList';
 import { graphql } from 'gatsby';
 import { PostListItemType } from 'types/PostItem.types';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
+import queryString, { ParsedQuery } from 'query-string';
 
 //categoryList props에 전달할 더미 데이터 생성
 const CATEGORY_LIST = {
@@ -27,6 +28,9 @@ const Container = styled.div`
 
 //쿼리로 받아온 데이터 타입을 지정합니다.
 type IndexPageProps = {
+  location: {
+    search: string
+  }
     data: {
       allMarkdownRemark: {
         edges: PostListItemType[]
@@ -40,6 +44,7 @@ type IndexPageProps = {
   }
 
 const IndexPage: FunctionComponent<IndexPageProps> = function({
+  location: {search},
     data: {
         allMarkdownRemark: { edges },
         file: {
@@ -47,11 +52,16 @@ const IndexPage: FunctionComponent<IndexPageProps> = function({
         }
     },
 }){
+  const parsed: ParsedQuery<string> = queryString.parse(search)
+  const selectedCategory : string = 
+    typeof parsed.category !== 'string' || !parsed.category
+      ? 'All'
+      : parsed.category
     return (
         <Container>
             <GlobalStyle />
             <Introduction profileImage={gatsbyImageData}/>
-            <CategoryList selectedCategory='Web' categoryList={CATEGORY_LIST}/>
+            <CategoryList selectedCategory={selectedCategory} categoryList={CATEGORY_LIST}/>
             <PostList posts={edges}/>
             <Footer />
         </Container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10051,6 +10051,16 @@ query-string@^6.13.8, query-string@^6.14.1:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
+query-string@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"


### PR DESCRIPTION
### URL 카테고리 파싱

- Gatsby의 URL 쿼리를 props로 받아올 수 있습니다. (파싱)
- URL parser 라이브러리인 query-string 라이브러리를 설치했습니다.