### PR TITLE
Develop

### DIFF
--- a/src/components/@common/Footer/Footer.tsx
+++ b/src/components/@common/Footer/Footer.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import * as S from './Footer.styles';
 
-const Footer: FunctionComponent = function () {
+const Footer = function () {
   return (
     <S.Container>
       Thank You for Visiting My Blog, Have a Good Day🌼❤️

--- a/src/components/@common/Footer/Footer.tsx
+++ b/src/components/@common/Footer/Footer.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import * as S from './Footer.styles';
 
-const Footer = function () {
+function Footer() {
   return (
     <S.Container>
       Thank You for Visiting My Blog, Have a Good Day🌼❤️
       <br />© 2022 Developer DaisyLee, Powered By Gatsby.
     </S.Container>
   );
-};
+}
 
 export default Footer;

--- a/src/components/CategoryList/CategoryList.tsx
+++ b/src/components/CategoryList/CategoryList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { Link } from 'gatsby';
 import * as S from './CategoryList.styles';
@@ -38,10 +38,7 @@ const CategoryItem = styled(({ active, ...props }: GatsbyLinkProps) => (
   }
 `;
 
-const CategoryList: FunctionComponent<CategoryListProps> = function ({
-  selectedCategory,
-  categoryList,
-}) {
+function CategoryList({ selectedCategory, categoryList }: CategoryListProps) {
   return (
     <S.Container>
       {Object.entries(categoryList).map(([name, count]) => (
@@ -55,6 +52,6 @@ const CategoryList: FunctionComponent<CategoryListProps> = function ({
       ))}
     </S.Container>
   );
-};
+}
 
 export default CategoryList;

--- a/src/components/Introduction/Introduction.tsx
+++ b/src/components/Introduction/Introduction.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import ProfileImage from 'components/ProfileImage/ProfileImage';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 import * as S from './Introduction.styles';
@@ -7,9 +7,7 @@ type IntroductionProps = {
   profileImage: IGatsbyImageData;
 };
 
-const Introduction: FunctionComponent<IntroductionProps> = function ({
-  profileImage,
-}) {
+function Introduction({ profileImage }: IntroductionProps) {
   return (
     <S.Background>
       <S.Container>
@@ -21,6 +19,6 @@ const Introduction: FunctionComponent<IntroductionProps> = function ({
       </S.Container>
     </S.Background>
   );
-};
+}
 
 export default Introduction;

--- a/src/components/PostItem/PostItem.tsx
+++ b/src/components/PostItem/PostItem.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { PostFrontmatterType } from 'types/PostItem.types';
 import * as S from './PostItem.styles';
 
 type PostItemProps = PostFrontmatterType & { link: string };
 
-const PostItem: FunctionComponent<PostItemProps> = function ({
+function PostItem({
   title,
   date,
   categories,
@@ -13,7 +13,7 @@ const PostItem: FunctionComponent<PostItemProps> = function ({
     childImageSharp: { gatsbyImageData },
   },
   link,
-}) {
+}: PostItemProps) {
   return (
     <S.Container to={link}>
       <S.ThumbnailImage image={gatsbyImageData} alt="Post Item Image" />
@@ -29,6 +29,6 @@ const PostItem: FunctionComponent<PostItemProps> = function ({
       </S.PostItemContent>
     </S.Container>
   );
-};
+}
 
 export default PostItem;

--- a/src/components/PostList/PostList.tsx
+++ b/src/components/PostList/PostList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import PostItem from '../PostItem/PostItem';
 import { PostListItemType } from 'types/PostItem.types';
 import * as S from './PostList.styles';
@@ -22,7 +22,7 @@ type PostListProps = {
   posts: PostListItemType[];
 };
 
-const PostList: FunctionComponent<PostListProps> = function ({ posts }) {
+function PostList({ posts }: PostListProps) {
   return (
     <S.Container>
       {posts.map(({ node: { id, frontmatter } }: PostListItemType) => (
@@ -30,6 +30,6 @@ const PostList: FunctionComponent<PostListProps> = function ({ posts }) {
       ))}
     </S.Container>
   );
-};
+}
 
 export default PostList;

--- a/src/components/ProfileImage/ProfileImage.tsx
+++ b/src/components/ProfileImage/ProfileImage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 import * as S from './ProfileImage.styles';
 
@@ -6,10 +6,8 @@ type ProfileImageProps = {
   profileImage: IGatsbyImageData;
 };
 
-const ProfileImage: FunctionComponent<ProfileImageProps> = function ({
-  profileImage,
-}) {
+function ProfileImage({ profileImage }: ProfileImageProps) {
   return <S.Container image={profileImage} alt="Profile Image" />;
-};
+}
 
 export default ProfileImage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
 import GlobalStyle from 'styles/GlobalStyle';
 import { Introduction, CategoryList, PostList } from 'components/index';
@@ -38,7 +38,7 @@ type IndexPageProps = {
   };
 };
 
-const IndexPage: FunctionComponent<IndexPageProps> = function ({
+function IndexPage({
   location: { search },
   data: {
     allMarkdownRemark: { edges },
@@ -46,7 +46,7 @@ const IndexPage: FunctionComponent<IndexPageProps> = function ({
       childImageSharp: { gatsbyImageData },
     },
   },
-}) {
+}: IndexPageProps) {
   const parsed: ParsedQuery<string> = queryString.parse(search);
   const selectedCategory: string =
     typeof parsed.category !== 'string' || !parsed.category
@@ -86,7 +86,7 @@ const IndexPage: FunctionComponent<IndexPageProps> = function ({
       <Footer />
     </Container>
   );
-};
+}
 
 export default IndexPage;
 

--- a/src/pages/info.tsx
+++ b/src/pages/info.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { graphql } from 'gatsby';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -15,13 +15,13 @@ type InfoPageProps = {
   };
 };
 
-const InfoPage: FunctionComponent<InfoPageProps> = function ({
+function InfoPage({
   data: {
     site: {
       siteMetadata: { title, description, author },
     },
   },
-}) {
+}: InfoPageProps) {
   return (
     <div>
       <Global styles={globalStyle} />
@@ -30,7 +30,7 @@ const InfoPage: FunctionComponent<InfoPageProps> = function ({
       <Text2 disable={true}>{author}</Text2>
     </div>
   );
-};
+}
 
 export default InfoPage;
 

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { Global, css } from '@emotion/react';
 
 const defaultStyle = css`
@@ -25,8 +25,8 @@ const defaultStyle = css`
   }
 `;
 
-const GlobalStyle: FunctionComponent = function () {
+function GlobalStyle() {
   return <Global styles={defaultStyle} />;
-};
+}
 
 export default GlobalStyle;


### PR DESCRIPTION
## FunctionCOmponent 타입을 더이상 사용하지 않습니다.

- 기존 코드에서는 리액트 함수형 컴포넌트의 타입을 지정하는 FuncitonComponent를 불러오도록 했습니다.
- 하지만 더이상 해당 타입을 불러올 필요가 없기 때문에, import 문을 제거했습니다.
- 또한 컴포넌트를 함수 선언문으로 정의했습니다.