### PR TITLE
♻️ Refactor: SEO 개선을 위한 CategoryItem 컴포넌트 생성

### DIFF
--- a/src/components/CategoryItem/CategoryItem.styles.ts
+++ b/src/components/CategoryItem/CategoryItem.styles.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { Link } from 'gatsby';
+import { CategoryItemProps } from './CategoryItem';
+
+export const Container = styled.div`
+  min-width: 48px;
+  height: 48px;
+  margin-right: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const StyledLlink = styled(Link)<CategoryItemProps>`
+  margin-right: 20px;
+  font-size: 15px;
+  font-weight: ${({ active }) => (active ? '800' : '400')};
+  cursor: pointer;
+
+  @media (max-width: 768px) {
+    font-size: 15px;
+  }
+
+  &:last-of-type {
+    margin-right: 0;
+  }
+`;

--- a/src/components/CategoryItem/CategoryItem.tsx
+++ b/src/components/CategoryItem/CategoryItem.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from 'react';
+import * as S from './CategoryItem.styles';
+
+export type CategoryItemProps = {
+  children: ReactNode;
+  className?: string;
+  to: string;
+  active: boolean;
+};
+
+const CategoryItem = ({ children, active, to }: CategoryItemProps) => {
+  return (
+    <S.Container>
+      <S.StyledLlink active to={to}>
+        {children}
+      </S.StyledLlink>
+    </S.Container>
+  );
+};
+
+export default CategoryItem;

--- a/src/components/CategoryList/CategoryList.tsx
+++ b/src/components/CategoryList/CategoryList.tsx
@@ -1,17 +1,6 @@
-import React, { ReactNode } from 'react';
-import styled from '@emotion/styled';
-import { Link } from 'gatsby';
+import React from 'react';
 import * as S from './CategoryList.styles';
-
-type CategoryItemProps = {
-  active: boolean;
-};
-
-type GatsbyLinkProps = {
-  children: ReactNode;
-  className?: string;
-  to: string;
-} & CategoryItemProps;
+import CategoryItem from 'components/CategoryItem/CategoryItem';
 
 export type CategoryListProps = {
   selectedCategory: string;
@@ -19,24 +8,6 @@ export type CategoryListProps = {
     [key: string]: number;
   };
 };
-
-const CategoryItem = styled(({ active, ...props }: GatsbyLinkProps) => (
-  <Link {...props} />
-))<CategoryItemProps>`
-  margin-right: 20px;
-  padding: 5px 0;
-  font-size: 18px;
-  font-weight: ${({ active }) => (active ? '800' : '400')};
-  cursor: pointer;
-
-  @media (max-width: 768px) {
-    font-size: 15px;
-  }
-
-  &:last-of-type {
-    margin-right: 0;
-  }
-`;
 
 function CategoryList({ selectedCategory, categoryList }: CategoryListProps) {
   return (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as CategoryItem } from './CategoryItem/CategoryItem';
 export { default as CategoryList } from './CategoryList/CategoryList';
 export { default as CommentWidget } from './CommentWidget/CommentWidget';
 export { default as Introduction } from './Introduction/Introduction';


### PR DESCRIPTION
## CategoryItem 컴포넌트 생성

### 코드 변경 이휴

- 기존 페이지의 SEO 성능은 98점으로, 카테고리 아이템의 최소 사이즈를 만들면 개선할 수 있다는 분석 결과를 받았습니다.
- 이를 위해 카테고리 아이템을 감싸는 컨테이너를 만들고 스타일링을 추가하고자 했습니다.
- 따라서  ``CategoryList`` 컴포넌트에 한 번에 선언되어 있던 ``CategoryItem``을 별개의 모듈로 분리했습니다.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/88873956/216531267-73de8e50-fb23-48d8-848d-f2b199dbdd6b.png">

-  카테고리 아이템의 최소 사이즈를 권장 사이즈인 48px x 48px로 설정했습니다.

### 코드 변경 효과

- 별도에 파일에 분리한 이후 최소 사이즈를 설정해 컴포넌트를 생성했고, SEO 점수가 98점에서 100점으로 상승했습니다.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/88873956/216531304-6d304240-00c4-46e9-bec9-e854b8ddeecf.png">
